### PR TITLE
添加visibleViews，只显示一类View。[[MMPlaceHolderConfig defaultConfig].visible…

### DIFF
--- a/MMPlaceHolder/MMPlaceHolder.h
+++ b/MMPlaceHolder/MMPlaceHolder.h
@@ -25,6 +25,7 @@
 
 @property (nonatomic, assign) BOOL visible;
 @property (nonatomic, assign) BOOL autoDisplay;
+@property (nonatomic, strong) NSMutableArray *visibleViews;
 
 @end
 

--- a/MMPlaceHolder/MMPlaceHolder.m
+++ b/MMPlaceHolder/MMPlaceHolder.m
@@ -35,6 +35,7 @@
         
         self.visible = YES;
         self.autoDisplay = NO;
+        self.visibleViews = [NSMutableArray array];
     }
     
     return self;
@@ -252,6 +253,13 @@
         if ( [MMPlaceHolderConfig defaultConfig].autoDisplay )
         {
             [self showPlaceHolder];
+        }
+        else if ([MMPlaceHolderConfig defaultConfig].visibleViews.count>0)
+        {
+            if([[MMPlaceHolderConfig defaultConfig].visibleViews containsObject:[self class]])
+            {
+                [self showPlaceHolder];
+            }
         }
     }
 }


### PR DESCRIPTION
假如我现在需要某一类View的Size信息。
通过[MMPlaceHolderConfig defaultConfig].autoDisplay = YES;会把所有的显示出来，界面会很乱。
所以添加visibleViews，显示某一类的信息。
